### PR TITLE
✨ [FEATURE] Forcer le format JSON sur toutes les requêtes API (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Le **backend de Cash Sights** constitue la brique serveur de l’écosystème. I
 
 🔗 Frontend associé : [Voir le dépôt](https://github.com/Horus-Turboss-Finance/web-interface)
 
+![Alt](https://repobeats.axiom.co/api/embed/417924da5d4eeace2d8cbf3980404ad1ba6f21c7.svg "Repobeats analytics image")
+
 ## ⚙️ Stack technique
 * **Node.js 23.6.0** - Runtime JavaScript côté serveur
 * **Express.js** - Framework HTTP minimaliste

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "backend-cashsight",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.11.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,6 +20,7 @@ import { requestLogger } from "./middleware/requestLogger";
 import { securityLogger } from "./middleware/securityLogger";
 import { ResponseException } from "./middleware/responseException";
 import { ResponseProtocole } from "./middleware/responseProtocole";
+import { validateContentType } from "./middleware/validateContentType";
 
 const app = express();
 
@@ -78,6 +79,8 @@ app.use(fileUpload({
     responseOnLimit: JSON.stringify(ResponseException("Fichier trop volumineux").PayloadTooLarge()),
     parseNested: true
 }))
+
+app.use(validateContentType)
 
 /** ===================== Metrics ===================== */
 app.use("/metrics", metricsRoute);

--- a/src/middleware/responseException.ts
+++ b/src/middleware/responseException.ts
@@ -4,6 +4,7 @@ const httpResponseDefinitions = [
   { key: "InvalidToken", code: 498 },
   { key: "TooManyRequests", code: 429 },
   { key: "IMATeapot", code: 418 },
+  { key: "UnsupportedMediaType", code: 415 },
   { key: "PayloadTooLarge", code: 413 },
   { key: "NotFound", code: 404 },
   { key: "MethodNotAllowed", code: 405 },
@@ -48,6 +49,10 @@ export class ClassResponseExceptions extends Error {
 
   IMATeapot() {
     return { status: ResponseCodes.IMATeapot, data: this.reason };
+  }
+
+  UnsupportedMediaType() {
+    return { status: ResponseCodes.UnsupportedMediaType, data: this.reason };
   }
 
   PayloadTooLarge() {

--- a/src/middleware/validateContentType.ts
+++ b/src/middleware/validateContentType.ts
@@ -1,0 +1,19 @@
+import { ResponseException } from './responseException';
+import { catchSync } from './catchError';
+
+/**
+ * Middleware global qui vérifie si la requête possède le header content type application/json lors d'une requête post put et patch.
+ *
+ * @returns Middleware Express
+ */
+export const validateContentType = catchSync(async (req, res, next) => {
+    const contentType = req.headers['content-type'];
+
+    if (req.method === 'POST' || req.method === 'PUT' || req.method === 'PATCH') {
+        if (!contentType || !contentType.includes('application/json')) {
+            throw ResponseException("Expected application/json content-type").UnsupportedMediaType();
+        }
+    }
+
+    next();
+});


### PR DESCRIPTION
# ✨ [FEATURE] Forcer le format JSON sur toutes les requêtes API (#13)
## Description
Cette PR introduit un middleware global Express visant à renforcer la validation des headers sur l'API, conformément à la proposition du ticket #13.
Elle permet de garantir que les requêtes avec payload (`POST`, `PUT`, `PATCH`) utilisent le format `application/json`, tout en normalisant les réponses d’erreur.

> [!NOTE]
> La validation du header `Accept` (et le rejet des requêtes ne déclarant pas explicitement `application/json`) a **été volontairement écartée** à ce stade. Voir la section Décision sur `Accept` ci-dessous pour plus de contexte.

## :white_check_mark: Ce qui a été implémenté
* Middleware global `validateContentType` :
  * Rejette les requêtes `POST`, `PUT`, `PATCH` dont le header `Content-Type` est absent ou différent de `application/json`
  * Retourne une réponse 415 `Unsupported Media Type` avec un body JSON standardisé
* Ajout du code d’erreur `UnsupportedMediaType` (415) dans le gestionnaire global `responseException`.
* Mise à jour du `README` pour s'alligner sur les readme du bot et de la web interface (je sais c'était pas dans le issue mais quand même).

## :no_entry_sign: Décision sur `Accept`
Initialement prévue dans le ticket, la validation du header `Accept` et le rejet des requêtes sans `Accept: application/json` (406) **n’a pas été implémentée**, suite à une analyse d’impact technique et fonctionnel :
* **Comportement par défaut d’Express** : la réponse est déjà formatée en `application/json` si le handler envoie un objet.
* **Interopérabilité** : certains clients ou outils (Postman, curl, scripts internes) n’envoient pas toujours `Accept`, sans que cela compromette la lecture de la réponse.
* **Robustesse > Rigidité** : s’aligner sur le principe de robustesse (`Postel’s Law`) évite des rejets inutiles pour des cas pourtant valides.
* **Aucun besoin immédiat identifié** : pas d’erreur de parsing ni de faille de sécurité induite dans notre cas d’usage actuel.

> *Cette validation pourra être réintroduite ultérieurement si des besoins concrets émergent (ex : compatibilité client, monitoring, règles de sécurité plus strictes).*

## :mag: Liens
* Ticket lié : Close #13
* Reviewer assigné : @docteur-turboss
* Auteur : @cashsights-reviews
* Label : `enhancement`